### PR TITLE
Change event to ServerConnectedEvent in listener

### DIFF
--- a/src/main/java/net/thenextlvl/tablist/listener/ConnectionListener.java
+++ b/src/main/java/net/thenextlvl/tablist/listener/ConnectionListener.java
@@ -2,7 +2,7 @@ package net.thenextlvl.tablist.listener;
 
 import com.velocitypowered.api.event.Subscribe;
 import com.velocitypowered.api.event.connection.DisconnectEvent;
-import com.velocitypowered.api.event.player.ServerPostConnectEvent;
+import com.velocitypowered.api.event.player.ServerConnectedEvent;
 import lombok.RequiredArgsConstructor;
 import net.thenextlvl.tablist.TablistPlugin;
 
@@ -13,8 +13,7 @@ public class ConnectionListener {
     private final TablistPlugin plugin;
 
     @Subscribe
-    @SuppressWarnings("UnstableApiUsage")
-    public void onServerConnect(ServerPostConnectEvent event) {
+    public void onServerConnect(ServerConnectedEvent event) {
         plugin.server().getAllPlayers().forEach(plugin::updateTablist);
     }
 


### PR DESCRIPTION
Replaced ServerPostConnectEvent with ServerConnectedEvent in ConnectionListener to ensure correct event handling. This aligns with the updated event structure and improves the robustness of the tab list update process.